### PR TITLE
Update Shape Constructors

### DIFF
--- a/modules/physics/Physics.lua
+++ b/modules/physics/Physics.lua
@@ -196,39 +196,50 @@ return {
         },
         {
             name = 'newCircleShape',
-            description = 'Create a new CircleShape at (x,y) in local coordinates.\n\nAnchors from the center of the shape by default.',
+            description = 'Creates a new CircleShape.',
             variants = {
-                {
-                    arguments = {
-                        {
-                            type = 'Body',
-                            name = 'body',
-                            description = 'The body to attach the shape to.'
-                        },
-                        {
-                            type = 'number',
-                            name = 'x',
-                            description = 'The x offset of the circle.'
-                        },
-                        {
-                            type = 'number',
-                            name = 'y',
-                            description = 'The y offset of the circle.'
-                        },
-                        {
-                            type = 'number',
-                            name = 'radius',
-                            description = 'The radius of the circle.'
-                        }
-                    },
-                    returns = {
-                        {
-                            type = 'CircleShape',
-                            name = 'shape',
-                            description = 'A new CircleShape.'
-                        }
-                    }
-                }
+              {
+                  arguments = {
+                      {
+                          type = 'number',
+                          name = 'radius',
+                          description = 'The radius of the circle.'
+                      }
+                  },
+                  returns = {
+                      {
+                          type = 'CircleShape',
+                          name = 'shape',
+                          description = 'The new shape.'
+                      }
+                  }
+              },
+              {
+                  arguments = {
+                      {
+                          type = 'number',
+                          name = 'x',
+                          description = 'The x offset of the circle.'
+                      },
+                      {
+                          type = 'number',
+                          name = 'y',
+                          description = 'The y offset of the circle.'
+                      },
+                      {
+                          type = 'number',
+                          name = 'radius',
+                          description = 'The radius of the circle.'
+                      }
+                  },
+                  returns = {
+                      {
+                          type = 'CircleShape',
+                          name = 'shape',
+                          description = 'The new shape.'
+                      }
+                  }
+              }
             }
         },
         {

--- a/modules/physics/Physics.lua
+++ b/modules/physics/Physics.lua
@@ -660,15 +660,31 @@ return {
         },
         {
             name = 'newRectangleShape',
-            description = 'Shorthand for creating rectangluar PolygonShapes.\n\nThe rectangle will be created at (x,y) in local coordinates.\n\nAnchors from the center of the shape by default.',
+            description = 'Shorthand for creating rectangluar PolygonShapes.\n\nBy default, the local origin is located at the center of the rectangle as opposed to the top left for graphics.',
             variants = {
                 {
                     arguments = {
                         {
-                            type = 'Body',
-                            name = 'body',
-                            description = 'The Body to attach the Shape to.'
+                            type = 'number',
+                            name = 'width',
+                            description = 'The width of the rectangle.'
                         },
+                        {
+                            type = 'number',
+                            name = 'height',
+                            description = 'The height of the rectangle.'
+                        }
+                    },
+                    returns = {
+                        {
+                            type = 'PolygonShape',
+                            name = 'shape',
+                            description = 'A new PolygonShape.'
+                        }
+                    }
+                },
+                {
+                    arguments = {
                         {
                             type = 'number',
                             name = 'x',


### PR DESCRIPTION
Some shape constructors were still expecting to take in 'Body' objects, which changed in a newer API version.