### PR TITLE
Allowed putting the directory inside a sub-folder.

### DIFF
--- a/love_api.lua
+++ b/love_api.lua
@@ -1,3 +1,5 @@
+local path = (...):match('(.-)[^%.]+$')
+
 return {
     functions = {
         {
@@ -32,23 +34,23 @@ return {
         }
     },
     modules = {
-        require('modules.audio.Audio'),
-        require('modules.event.Event'),
-        require('modules.filesystem.Filesystem'),
-        require('modules.graphics.Graphics'),
-        require('modules.image.Image'),
-        require('modules.joystick.Joystick'),
-        require('modules.keyboard.Keyboard'),
-        require('modules.math.Math'),
-        require('modules.mouse.Mouse'),
-        require('modules.physics.Physics'),
-        require('modules.sound.Sound'),
-        require('modules.system.System'),
-        require('modules.thread.Thread'),
-        require('modules.timer.Timer'),
-        require('modules.touch.Touch'),
-        require('modules.video.Video'),
-        require('modules.window.Window')
+        require(path .. 'modules.audio.Audio'),
+        require(path .. 'modules.event.Event'),
+        require(path .. 'modules.filesystem.Filesystem'),
+        require(path .. 'modules.graphics.Graphics'),
+        require(path .. 'modules.image.Image'),
+        require(path .. 'modules.joystick.Joystick'),
+        require(path .. 'modules.keyboard.Keyboard'),
+        require(path .. 'modules.math.Math'),
+        require(path .. 'modules.mouse.Mouse'),
+        require(path .. 'modules.physics.Physics'),
+        require(path .. 'modules.sound.Sound'),
+        require(path .. 'modules.system.System'),
+        require(path .. 'modules.thread.Thread'),
+        require(path .. 'modules.timer.Timer'),
+        require(path .. 'modules.touch.Touch'),
+        require(path .. 'modules.video.Video'),
+        require(path .. 'modules.window.Window')
     },
     types = {
         {

--- a/modules/audio/Audio.lua
+++ b/modules/audio/Audio.lua
@@ -1,8 +1,10 @@
+local path = (...):match('(.-)[^%.]+$')
+
 return {
     name = 'audio',
     description = 'Provides an interface to create noise with the user\'s speakers.',
     types = {
-        require('modules.audio.types.Source')
+        require(path .. 'types.Source')
     },
     functions = {
         {
@@ -475,8 +477,8 @@ return {
         }
     },
     enums = {
-        require('modules.audio.enums.DistanceModel'),
-        require('modules.audio.enums.SourceType'),
-        require('modules.audio.enums.TimeUnit')
+        require(path .. 'enums.DistanceModel'),
+        require(path .. 'enums.SourceType'),
+        require(path .. 'enums.TimeUnit')
     }
 };

--- a/modules/event/Event.lua
+++ b/modules/event/Event.lua
@@ -1,3 +1,5 @@
+local path = (...):match('(.-)[^%.]+$') .. '.' 
+
 return {
     name = 'event',
     description = 'Manages events, like keypresses.',
@@ -122,6 +124,6 @@ return {
         }
     },
     enums = {
-        require('modules.event.enums.Event')
+        require(path .. 'enums.Event')
     }
 }

--- a/modules/filesystem/Filesystem.lua
+++ b/modules/filesystem/Filesystem.lua
@@ -1,9 +1,11 @@
+local path = (...):match('(.-)[^%.]+$') .. '.'
+
 return {
     name = 'filesystem',
     description = 'Provides an interface to the user\'s filesystem.',
     types = {
-        require('modules.filesystem.types.File'),
-        require('modules.filesystem.types.FileData')
+        require(path .. 'types.File'),
+        require(path .. 'types.FileData')
     },
     functions = {
         {
@@ -729,8 +731,8 @@ return {
         }
     },
     enums = {
-        require('modules.filesystem.enums.BufferMode'),
-        require('modules.filesystem.enums.FileDecoder'),
-        require('modules.filesystem.enums.FileMode')
+        require(path .. 'enums.BufferMode'),
+        require(path .. 'enums.FileDecoder'),
+        require(path .. 'enums.FileMode')
     }
 }

--- a/modules/graphics/Graphics.lua
+++ b/modules/graphics/Graphics.lua
@@ -1,16 +1,18 @@
+local path = (...):match('(.-)[^%.]+$') .. '.'
+
 return {
     name = 'graphics',
     description = 'The primary responsibility for the love.graphics module is the drawing of lines, shapes, text, Images and other Drawable objects onto the screen. Its secondary responsibilities include loading external files (including Images and Fonts) into memory, creating specialized objects (such as ParticleSystems or Framebuffers) and managing screen geometry.\n\nLÖVE\'s coordinate system is rooted in the upper-left corner of the screen, which is at location (0, 0). The x-axis is horizontal: larger values are further to the right. The y-axis is vertical: larger values are further towards the bottom.\n\nIn many cases, you draw images or shapes in terms of their upper-left corner (See the picture above).\n\nMany of the functions are used to manipulate the graphics coordinate system, which is essentially the way coordinates are mapped to the display. You can change the position, scale, and even rotation in this way.',
     types = {
-        require('modules.graphics.types.Canvas'),
-        require('modules.graphics.types.Font'),
-        require('modules.graphics.types.Mesh'),
-        require('modules.graphics.types.Image'),
-        require('modules.graphics.types.ParticleSystem'),
-        require('modules.graphics.types.Quad'),
-        require('modules.graphics.types.Shader'),
-        require('modules.graphics.types.SpriteBatch'),
-        require('modules.graphics.types.Text')
+        require(path .. 'types.Canvas'),
+        require(path .. 'types.Font'),
+        require(path .. 'types.Mesh'),
+        require(path .. 'types.Image'),
+        require(path .. 'types.ParticleSystem'),
+        require(path .. 'types.Quad'),
+        require(path .. 'types.Shader'),
+        require(path .. 'types.SpriteBatch'),
+        require(path .. 'types.Text')
     },
     functions = {
         {
@@ -2890,22 +2892,22 @@ return {
         }
     },
     enums = {
-        require('modules.graphics.enums.AlignMode'),
-        require('modules.graphics.enums.AreaSpreadDistribution'),
-        require('modules.graphics.enums.BlendMode'),
-        require('modules.graphics.enums.CanvasFormat'),
-        require('modules.graphics.enums.DrawMode'),
-        require('modules.graphics.enums.FilterMode'),
-        require('modules.graphics.enums.GraphicsFeature'),
-        require('modules.graphics.enums.GraphicsLimit'),
-        require('modules.graphics.enums.LineJoin'),
-        require('modules.graphics.enums.LineStyle'),
-        require('modules.graphics.enums.MeshDrawMode'),
-        require('modules.graphics.enums.ParticleInsertMode'),
-        require('modules.graphics.enums.PointStyle'),
-        require('modules.graphics.enums.SpriteBatchUsage'),
-        require('modules.graphics.enums.StackType'),
-        require('modules.graphics.enums.TextureFormat'),
-        require('modules.graphics.enums.WrapMode')
+        require(path .. 'enums.AlignMode'),
+        require(path .. 'enums.AreaSpreadDistribution'),
+        require(path .. 'enums.BlendMode'),
+        require(path .. 'enums.CanvasFormat'),
+        require(path .. 'enums.DrawMode'),
+        require(path .. 'enums.FilterMode'),
+        require(path .. 'enums.GraphicsFeature'),
+        require(path .. 'enums.GraphicsLimit'),
+        require(path .. 'enums.LineJoin'),
+        require(path .. 'enums.LineStyle'),
+        require(path .. 'enums.MeshDrawMode'),
+        require(path .. 'enums.ParticleInsertMode'),
+        require(path .. 'enums.PointStyle'),
+        require(path .. 'enums.SpriteBatchUsage'),
+        require(path .. 'enums.StackType'),
+        require(path .. 'enums.TextureFormat'),
+        require(path .. 'enums.WrapMode')
     }
 }

--- a/modules/image/Image.lua
+++ b/modules/image/Image.lua
@@ -1,9 +1,11 @@
+local path = (...):match('(.-)[^%.]+$') .. '.'
+
 return {
     name = 'image',
     description = 'Provides an interface to decode encoded image data.',
     types = {
-        require('modules.image.types.CompressedImageData'),
-        require('modules.image.types.ImageData'),
+        require(path .. 'types.CompressedImageData'),
+        require(path .. 'types.ImageData'),
     },
     functions = {
         {
@@ -159,7 +161,7 @@ return {
         }
     },
     enums = {
-        require('modules.image.enums.CompressedImageFormat'),
-        require('modules.image.enums.ImageFormat')
+        require(path .. 'enums.CompressedImageFormat'),
+        require(path .. 'enums.ImageFormat')
     }
 }

--- a/modules/joystick/Joystick.lua
+++ b/modules/joystick/Joystick.lua
@@ -1,8 +1,10 @@
+local path = (...):match('(.-)[^%.]+$') .. '.'
+
 return {
     name = 'joystick',
     description = 'Provides an interface to the user\'s joystick.',
     types = {
-        require('modules.joystick.types.Joystick')
+        require(path .. 'types.Joystick')
     },
     functions = {
         {
@@ -170,9 +172,9 @@ return {
         }
     },
     enums = {
-        require('modules.joystick.enums.GamepadAxis'),
-        require('modules.joystick.enums.GamepadButton'),
-        require('modules.joystick.enums.JoystickHat'),
-        require('modules.joystick.enums.JoystickInputType')
+        require(path .. 'enums.GamepadAxis'),
+        require(path .. 'enums.GamepadButton'),
+        require(path .. 'enums.JoystickHat'),
+        require(path .. 'enums.JoystickInputType')
     }
 }

--- a/modules/keyboard/Keyboard.lua
+++ b/modules/keyboard/Keyboard.lua
@@ -1,3 +1,5 @@
+local path = (...):match('(.-)[^%.]+$') .. '.'
+
 return {
     name = 'keyboard',
     description = 'Provides an interface to the user\'s keyboard.',
@@ -178,6 +180,6 @@ return {
         }
     },
     enums = {
-        require('modules.keyboard.enums.KeyConstant')
+        require(path .. 'enums.KeyConstant')
     }
 }

--- a/modules/math/Math.lua
+++ b/modules/math/Math.lua
@@ -1,10 +1,12 @@
+local path = (...):match('(.-)[^%.]+$') .. '.'
+
 return {
     name = 'math',
     description = 'Provides system-independent mathematical functions.',
     types = {
-        require('modules.math.types.BezierCurve'),
-        require('modules.math.types.CompressedData'),
-        require('modules.math.types.RandomGenerator')
+        require(path .. 'types.BezierCurve'),
+        require(path .. 'types.CompressedData'),
+        require(path .. 'types.RandomGenerator')
     },
     functions = {
         {
@@ -826,6 +828,6 @@ return {
         }
     },
     enums = {
-        require('modules.math.enums.CompressedDataFormat')
+        require(path .. 'enums.CompressedDataFormat')
     }
 }

--- a/modules/mouse/Mouse.lua
+++ b/modules/mouse/Mouse.lua
@@ -1,8 +1,10 @@
+local path = (...):match('(.-)[^%.]+$') .. '.'
+
 return {
     name = 'mouse',
     description = 'Provides an interface to the user\'s mouse.',
     types = {
-        require('modules.mouse.types.Cursor')
+        require(path .. 'types.Cursor')
     },
     functions = {
         {
@@ -398,6 +400,6 @@ return {
         }
     },
     enums = {
-        require('modules.mouse.enums.CursorType')
+        require(path .. 'enums.CursorType')
     }
 }

--- a/modules/physics/Physics.lua
+++ b/modules/physics/Physics.lua
@@ -1,27 +1,29 @@
+local path = (...):match('(.-)[^%.]+$') .. '.'
+
 return {
     name = 'physics',
     description = 'Can simulate 2D rigid body physics in a realistic manner. This module is based on Box2D, and this API corresponds to the Box2D API as closely as possible.',
     types = {
-        require('modules.physics.types.Body'),
-        require('modules.physics.types.ChainShape'),
-        require('modules.physics.types.CircleShape'),
-        require('modules.physics.types.Contact'),
-        require('modules.physics.types.EdgeShape'),
-        require('modules.physics.types.DistanceJoint'),
-        require('modules.physics.types.Fixture'),
-        require('modules.physics.types.FrictionJoint'),
-        require('modules.physics.types.GearJoint'),
-        require('modules.physics.types.Joint'),
-        require('modules.physics.types.MouseJoint'),
-        require('modules.physics.types.PolygonShape'),
-        require('modules.physics.types.PrismaticJoint'),
-        require('modules.physics.types.PulleyJoint'),
-        require('modules.physics.types.RevoluteJoint'),
-        require('modules.physics.types.RopeJoint'),
-        require('modules.physics.types.Shape'),
-        require('modules.physics.types.WeldJoint'),
-        require('modules.physics.types.WheelJoint'),
-        require('modules.physics.types.World')
+        require(path .. 'types.Body'),
+        require(path .. 'types.ChainShape'),
+        require(path .. 'types.CircleShape'),
+        require(path .. 'types.Contact'),
+        require(path .. 'types.EdgeShape'),
+        require(path .. 'types.DistanceJoint'),
+        require(path .. 'types.Fixture'),
+        require(path .. 'types.FrictionJoint'),
+        require(path .. 'types.GearJoint'),
+        require(path .. 'types.Joint'),
+        require(path .. 'types.MouseJoint'),
+        require(path .. 'types.PolygonShape'),
+        require(path .. 'types.PrismaticJoint'),
+        require(path .. 'types.PulleyJoint'),
+        require(path .. 'types.RevoluteJoint'),
+        require(path .. 'types.RopeJoint'),
+        require(path .. 'types.Shape'),
+        require(path .. 'types.WeldJoint'),
+        require(path .. 'types.WheelJoint'),
+        require(path .. 'types.World')
     },
     functions = {
         {
@@ -1038,8 +1040,8 @@ return {
         }
     },
     enums = {
-        require('modules.physics.enums.BodyType'),
-        require('modules.physics.enums.JointType'),
-        require('modules.physics.enums.ShapeType')
+        require(path .. 'enums.BodyType'),
+        require(path .. 'enums.JointType'),
+        require(path .. 'enums.ShapeType')
     }
 }

--- a/modules/sound/Sound.lua
+++ b/modules/sound/Sound.lua
@@ -1,9 +1,11 @@
+local path = (...):match('(.-)[^%.]+$') .. '.'
+
 return {
     name = 'sound',
     description = 'This module is responsible for decoding sound files. It can\'t play the sounds, see love.audio for that.',
     types = {
-        require('modules.sound.types.Decoder'),
-        require('modules.sound.types.SoundData')
+        require(path .. 'types.Decoder'),
+        require(path .. 'types.SoundData')
     },
     functions = {
         {

--- a/modules/system/System.lua
+++ b/modules/system/System.lua
@@ -1,3 +1,5 @@
+local path = (...):match('(.-)[^%.]+$') .. '.'
+
 return {
     name = 'system',
     description = 'Provides access to information about the user\'s system.',
@@ -127,6 +129,6 @@ return {
         }
     },
     enums = {
-        require('modules.system.enums.PowerState')
+        require(path .. 'enums.PowerState')
     }
 }

--- a/modules/thread/Thread.lua
+++ b/modules/thread/Thread.lua
@@ -1,9 +1,11 @@
+local path = (...):match('(.-)[^%.]+$') .. '.'
+
 return {
     name = 'thread',
     description = 'Allows you to work with threads.\n\nThreads are separate Lua environments, running in parallel to the main code. As their code runs separately, they can be used to compute complex operations without adversely affecting the frame rate of the main thread. However, as they are separate environments, they cannot access the variables and functions of the main thread, and communication between threads is limited.\n\nAll LOVE objects (userdata) are shared among threads so you\'ll only have to send their references across threads. You may run into concurrency issues if you manipulate an object on multiple threads at the same time.\n\nWhen a Thread is started, it only loads the love.thread module. Every other module has to be loaded with require.',
     types = {
-        require('modules.thread.types.Thread'),
-        require('modules.thread.types.Channel')
+        require(path .. 'types.Thread'),
+        require(path .. 'types.Channel')
     },
     functions = {
         {

--- a/modules/video/Video.lua
+++ b/modules/video/Video.lua
@@ -1,8 +1,10 @@
+local path = (...):match('(.-)[^%.]+$') .. '.'
+
 return {
     name = 'video',
     description = 'This module is responsible for decoding, controlling, and streaming video files.\n\nIt can\'t draw the videos, see love.graphics.newVideo and Video objects for that.',
     types = {
-        require('modules.video.types.Video')
+        require(path .. 'types.Video')
     },
     functions = {
         {

--- a/modules/window/Window.lua
+++ b/modules/window/Window.lua
@@ -1,3 +1,5 @@
+local path = (...):match('(.-)[^%.]+$') .. '.'
+
 return {
     name = 'window',
     description = 'Provides an interface for modifying and retrieving information about the program\'s window.',
@@ -753,6 +755,6 @@ return {
         }
     },
     enums = {
-        require('modules.window.enums.FullscreenType')
+        require(path .. 'enums.FullscreenType')
     }
 }


### PR DESCRIPTION
I'm working on auto-generating the coloring for Vim. To do this, I have a batch file that looks something like this:
```batch
@echo off
:: If run via admin, cd is System32
cd %~dp0

:: Get most up-to-date version
rd love-api
git clone https://github.com/rm-code/love-api

"C:\Program Files\LOVE\0.10.0\love" . >out.txt

:: Cleanup
rd love-api
```

Then, main.lua looks like this:
```lua
api = require 'love-api.love_api'

-- etc.
-- Anything `print`ed will be output to out.txt
-- For instance: 
print( 'love.' .. api.functions[1].name )
```

Without these modifications, I get errors, because the files being required aren't in the base directory, so `require` cannot find the files.